### PR TITLE
Update mdss_mdp_trace.h

### DIFF
--- a/drivers/video/msm/mdss/mdss_mdp_trace.h
+++ b/drivers/video/msm/mdss/mdss_mdp_trace.h
@@ -17,7 +17,7 @@
 #undef TRACE_SYSTEM
 #define TRACE_SYSTEM mdss
 #undef TRACE_INCLUDE_PATH
-#define TRACE_INCLUDE_PATH .
+#define TRACE_INCLUDE_PATH ../../drivers/video/msm/mdss
 #undef TRACE_INCLUDE_FILE
 #define TRACE_INCLUDE_FILE mdss_mdp_trace
 


### PR DESCRIPTION
To fix This  kernel compilation error:

included from drivers/video/msm/mdss/mdss_mdp_trace.h:404:0,from drivers/video/msm/mdss/mdss_debug.h:23,from drivers/video/msm/mdss/mdss_fb.c:58:include/trace/define_trace.h:79:43: fatal error: ./mdss_mdp_trace.h: No such file or directory